### PR TITLE
[build] drop 1.9.3; Travis: use dist: trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 dist: trusty
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.4.1
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
This PR does the smallest change to the Travis configuration to get a build on the new default environment.

- use dist: trusty
- remove 1.9.3 support (using commonmarker does that)

The result is a build with **no "errors" only build "failures"**.