### PR TITLE
Travis: use an installed Ruby 2.4 in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 dist: trusty
 rvm:
   - 2.0.0
-  - 2.4.1
+  - 2.4.2
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.0.0
   - 2.4
   - ruby-head
+cache:
+  bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 dist: trusty
 rvm:
   - 2.0.0
-  - 2.4.2
+  - 2.4
   - ruby-head


### PR DESCRIPTION
This updates the CI matrix to use Ruby 2.4.2.

---

**Experiment**: use `2.4` instead, which writes:

```
$ rvm alias create 2.4 ruby-2.4.1
```

which uses a pre-installed Ruby version.

(Also, cache bundler.)